### PR TITLE
Fix readme example docblock, change param to return

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Read the [documentation](https://doc.maybe.texthtml.net) full API description, d
 
 ```php
 /**
- * @param Option<float>
+ * @return Option<float>
  */
 function divide(float $numerator, float $denominator): Option {
     return match ($denomintor) {
@@ -53,7 +53,7 @@ if ($result->isSome()) {
 
 ```php
 /**
- * @param Result<int,string>
+ * @return Result<int,string>
  */
 function parse_version(string $header): Result {
     return match ($header[0] ?? null) {


### PR DESCRIPTION
Great library! I've created nearly identical pieces of code, but none nearly as comprehensive as what you have here!

I think the readme should have `@return` instead of `@param`? (Otherwise it looks like it's trying to describe `string $header`)