### PR TITLE
Convert PHPUnit annotations to attributes

### DIFF
--- a/tests/Unit/Option/BooleanTest.php
+++ b/tests/Unit/Option/BooleanTest.php
@@ -4,6 +4,7 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Tests\Provider;
 
@@ -12,24 +13,24 @@ final class BooleanTest extends TestCase
     use Provider\Options;
 
     /**
-     * @dataProvider andMatrix
      * @template T
      * @param Option<T> $left
      * @param Option<T> $right
      * @param Option<T> $expected
      */
+     #[DataProvider('andMatrix')]
     public function testAnd(Option $left, Option $right, Option $expected): void
     {
         Assert::assertSame($expected, $left->and($right));
     }
 
     /**
-     * @dataProvider andMatrix
      * @template T
      * @param Option<T> $left
      * @param Option<T> $right
      * @param Option<T> $expected
      */
+     #[DataProvider('andMatrix')]
     public function testAndThen(Option $left, Option $right, Option $expected): void
     {
         $calls = [];
@@ -47,12 +48,12 @@ final class BooleanTest extends TestCase
     }
 
     /**
-     * @dataProvider orMatrix
      * @template T
      * @param Option<T> $left
      * @param Option<T> $right
      * @param Option<T> $expected
      */
+     #[DataProvider('orMatrix')]
     public function testOrElse(Option $left, Option $right, Option $expected): void
     {
         $calls = 0;
@@ -70,24 +71,24 @@ final class BooleanTest extends TestCase
     }
 
     /**
-     * @dataProvider orMatrix
      * @template T
      * @param Option<T> $left
      * @param Option<T> $right
      * @param Option<T> $expected
      */
+     #[DataProvider('orMatrix')]
     public function testOr(Option $left, Option $right, Option $expected): void
     {
         Assert::assertSame($expected, $left->or($right));
     }
 
     /**
-     * @dataProvider xorMatrix
      * @template T
      * @param Option<T> $left
      * @param Option<T> $right
      * @param Option<T> $expected
      */
+     #[DataProvider('xorMatrix')]
     public function testXor(Option $left, Option $right, Option $expected): void
     {
         Assert::assertEquals($expected, $left->xor($right));

--- a/tests/Unit/Option/ContainsTest.php
+++ b/tests/Unit/Option/ContainsTest.php
@@ -4,6 +4,7 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Tests\Provider;
 
@@ -12,9 +13,9 @@ final class ContainsTest extends TestCase
     use Provider\Values;
 
     /**
-     * @dataProvider containsMatrix
      * @param Option<mixed> $option
      */
+     #[DataProvider('containsMatrix')]
     public function testContains(Option $option, mixed $value, bool $expect, bool $strict = true): void
     {
         Assert::assertSame($expect, $option->contains($value, strict: $strict));

--- a/tests/Unit/Option/ConvertToResultTest.php
+++ b/tests/Unit/Option/ConvertToResultTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
@@ -13,10 +14,10 @@ final class ConvertToResultTest extends TestCase
     use Provider\Transpose;
 
     /**
-     * @dataProvider okOrMatrix
      * @param Option<mixed> $option
      * @param Result<mixed, mixed> $expected
      */
+     #[DataProvider('okOrMatrix')]
     public function testOkOr(Option $option, mixed $err, Result $expected): void
     {
         Assert::assertEquals($expected, $result = $option->okOr($err));
@@ -26,10 +27,10 @@ final class ConvertToResultTest extends TestCase
     }
 
     /**
-     * @dataProvider okOrMatrix
      * @param Option<mixed> $option
      * @param Result<mixed, mixed> $expected
      */
+     #[DataProvider('okOrMatrix')]
     public function testOkOrElse(Option $option, mixed $err, Result $expected, int $expectedCalls): void
     {
         $calls = 0;
@@ -67,10 +68,10 @@ final class ConvertToResultTest extends TestCase
     }
 
     /**
-     * @dataProvider transposeMatrix
      * @param Option<Result<mixed, mixed>> $option
      * @param Result<mixed, mixed> $expected
      */
+     #[DataProvider('transposeMatrix')]
     public function testTranspose(Option $option, Result $expected): void
     {
         Assert::assertEquals($expected, $result = Option\transpose($option));

--- a/tests/Unit/Option/FilterTest.php
+++ b/tests/Unit/Option/FilterTest.php
@@ -4,16 +4,17 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 
 final class FilterTest extends TestCase
 {
     /**
-     * @dataProvider filterMatrix
      * @template T
      * @param Option<T> $option
      * @param array<T> $expectedCalls
      */
+     #[DataProvider('filterMatrix')]
     public function testFilter(Option $option, bool $filterResult, bool $expectNone, array $expectedCalls): void
     {
         $calls = [];

--- a/tests/Unit/Option/FlattenTest.php
+++ b/tests/Unit/Option/FlattenTest.php
@@ -4,15 +4,16 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 
 final class FlattenTest extends TestCase
 {
     /**
-     * @dataProvider flattenMatrix
      * @param Option<mixed> $expected
      * @param Option<Option<mixed>> $option
      */
+     #[DataProvider('flattenMatrix')]
     public function testFlatten(Option $expected, Option $option): void
     {
         Assert::assertEquals($expected, Option\flatten($option));

--- a/tests/Unit/Option/FromValueTest.php
+++ b/tests/Unit/Option/FromValueTest.php
@@ -4,6 +4,7 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Tests\Provider;
 
@@ -12,9 +13,9 @@ final class FromValueTest extends TestCase
     use Provider\Options;
 
     /**
-     * @dataProvider fromValueMatrix
      * @param Option<mixed> $expected
      */
+     #[DataProvider('fromValueMatrix')]
     public function testFromValue(Option $expected, mixed $value, mixed $noneValue, bool $strict = true): void
     {
         Assert::assertEquals($expected, Option\fromValue($value, $noneValue, strict: $strict));

--- a/tests/Unit/Option/InspectTest.php
+++ b/tests/Unit/Option/InspectTest.php
@@ -4,6 +4,7 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Tests\Provider;
 
@@ -12,8 +13,8 @@ final class InspectTest extends TestCase
     use Provider\Values;
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testInspectSome(mixed $value): void
     {
         $option = Option\some($value);

--- a/tests/Unit/Option/IsTest.php
+++ b/tests/Unit/Option/IsTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Tests\Assert;
 use TH\Maybe\Tests\Provider;
@@ -12,8 +13,8 @@ final class IsTest extends TestCase
     use Provider\Values;
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testIsSome(mixed $value): void
     {
         $option = Option\some($value);
@@ -26,8 +27,8 @@ final class IsTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testIsNone(mixed $value): void
     {
         $option = Option\some($value);
@@ -40,8 +41,8 @@ final class IsTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testIsSomeAnd(mixed $value): void
     {
         $option = Option\some($value);

--- a/tests/Unit/Option/MapTest.php
+++ b/tests/Unit/Option/MapTest.php
@@ -4,12 +4,12 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 
 final class MapTest extends TestCase
 {
     /**
-     * @dataProvider mapMatrix
      * @template T
      * @template U
      * @param Option<T> $option
@@ -17,6 +17,7 @@ final class MapTest extends TestCase
      * @param Option<U> $expected
      * @param array<T> $expectedCalls
      */
+     #[DataProvider('mapMatrix')]
     public function testMap(Option $option, mixed $mapResult, Option $expected, array $expectedCalls): void
     {
         $calls = [];
@@ -59,7 +60,6 @@ final class MapTest extends TestCase
     }
 
     /**
-     * @dataProvider mapOrMatrix
      * @template T
      * @template U
      * @param Option<T> $option
@@ -68,6 +68,7 @@ final class MapTest extends TestCase
      * @param U $expected
      * @param array<T> $expectedCalls
      */
+     #[DataProvider('mapOrMatrix')]
     public function testMapOr(
         Option $option,
         mixed $mapResult,

--- a/tests/Unit/Option/OfTest.php
+++ b/tests/Unit/Option/OfTest.php
@@ -4,6 +4,7 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Tests\Provider;
 
@@ -12,18 +13,18 @@ final class OfTest extends TestCase
     use Provider\Options;
 
     /**
-     * @dataProvider fromValueMatrix
      * @param Option<mixed> $expected
      */
+     #[DataProvider('fromValueMatrix')]
     public function testOf(Option $expected, mixed $value, mixed $noneValue, bool $strict = true): void
     {
         Assert::assertEquals($expected, Option\of(static fn () => $value, $noneValue, strict: $strict));
     }
 
     /**
-     * @dataProvider fromValueMatrix
      * @param Option<mixed> $expected
      */
+     #[DataProvider('fromValueMatrix')]
     public function testTryOf(Option $expected, mixed $value, mixed $noneValue, bool $strict = true): void
     {
         Assert::assertEquals($expected, Option\tryOf(static fn () => $value, $noneValue, strict: $strict));

--- a/tests/Unit/Option/SerializationTest.php
+++ b/tests/Unit/Option/SerializationTest.php
@@ -4,6 +4,7 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Tests\Provider;
 
@@ -20,8 +21,8 @@ final class SerializationTest extends TestCase
     }
 
     /**
-     * @dataProvider serializableValues
      */
+     #[DataProvider('serializableValues')]
     public function testWithSomeValidValues(mixed $value): void
     {
         $this->testSerializableOption(Option\some($value));

--- a/tests/Unit/Option/UnwrapTest.php
+++ b/tests/Unit/Option/UnwrapTest.php
@@ -4,6 +4,7 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Tests\Provider;
 
@@ -19,8 +20,8 @@ final class UnwrapTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testExpectSome(mixed $value): void
     {
         Assert::assertSame($value, Option\some($value)->expect("This should succeed"));
@@ -34,40 +35,40 @@ final class UnwrapTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapSome(mixed $value): void
     {
         Assert::assertSame($value, Option\some($value)->unwrap());
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOrNone(mixed $value): void
     {
         Assert::assertSame($value, Option\none()->unwrapOr($value));
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOrSome(mixed $value): void
     {
         Assert::assertSame($value, Option\some($value)->unwrapOr(false));
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOrElseNone(mixed $value): void
     {
         Assert::assertSame($value, Option\none()->unwrapOrElse(static fn () => $value));
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOrElseSome(mixed $value): void
     {
         Assert::assertSame($value, Option\some($value)->unwrapOrElse(static fn () => false));

--- a/tests/Unit/Option/ZipTest.php
+++ b/tests/Unit/Option/ZipTest.php
@@ -4,18 +4,19 @@ namespace TH\Maybe\Tests\Unit\Option;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 
 final class ZipTest extends TestCase
 {
     /**
-     * @dataProvider zipMatrix
      * @template L
      * @template R
      * @param Option<L> $left
      * @param Option<R> $right
      * @param Option<array{L, R}> $expected
      */
+     #[DataProvider('zipMatrix')]
     public function testZip(Option $left, Option $right, Option $expected): void
     {
         Assert::assertEquals($expected, $left->zip($right));
@@ -56,13 +57,13 @@ final class ZipTest extends TestCase
     }
 
     /**
-     * @dataProvider unzipMatrix
      * @template L
      * @template R
      * @param Option<array{L, R}> $zipped
      * @param Option<L> $left
      * @param Option<R> $right
      */
+     #[DataProvider('unzipMatrix')]
     public function testUnzip(Option $zipped, Option $left, Option $right): void
     {
         Assert::assertEquals([$left, $right], Option\unzip($zipped));

--- a/tests/Unit/Result/BooleanTest.php
+++ b/tests/Unit/Result/BooleanTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
 use TH\Maybe\Tests\Provider;
@@ -12,12 +13,12 @@ final class BooleanTest extends TestCase
     use Provider\Results;
 
     /**
-     * @dataProvider andMatrix
      * @template T
      * @param Result<T, mixed> $left
      * @param Result<T, mixed> $right
      * @param Result<T, mixed> $expected
      */
+     #[DataProvider('andMatrix')]
     public function testAnd(Result $left, Result $right, Result $expected): void
     {
         Assert::assertEquals($expected, $result = $left->and($right));
@@ -29,12 +30,12 @@ final class BooleanTest extends TestCase
     }
 
     /**
-     * @dataProvider andMatrix
      * @template T
      * @param Result<T, mixed> $left
      * @param Result<T, mixed> $right
      * @param Result<T, mixed> $expected
      */
+     #[DataProvider('andMatrix')]
     public function testAndThen(Result $left, Result $right, Result $expected): void
     {
         $calls = [];
@@ -64,12 +65,12 @@ final class BooleanTest extends TestCase
     }
 
     /**
-     * @dataProvider orMatrix
      * @template T
      * @param Result<T, mixed> $left
      * @param Result<T, mixed> $right
      * @param Result<T, mixed> $expected
      */
+     #[DataProvider('orMatrix')]
     public function testOrElse(Result $left, Result $right, Result $expected): void
     {
         $calls = 0;
@@ -97,12 +98,12 @@ final class BooleanTest extends TestCase
     }
 
     /**
-     * @dataProvider orMatrix
      * @template T
      * @param Result<T, mixed> $left
      * @param Result<T, mixed> $right
      * @param Result<T, mixed> $expected
      */
+     #[DataProvider('orMatrix')]
     public function testOr(Result $left, Result $right, Result $expected): void
     {
         Assert::assertEquals($expected, $result = $left->or($right));

--- a/tests/Unit/Result/ContainsTest.php
+++ b/tests/Unit/Result/ContainsTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
 use TH\Maybe\Tests\Provider;
@@ -12,9 +13,9 @@ final class ContainsTest extends TestCase
     use Provider\Values;
 
     /**
-     * @dataProvider containsMatrix
      * @param Result<mixed, null> $result
      */
+     #[DataProvider('containsMatrix')]
     public function testContains(Result $result, mixed $value, bool $expect, bool $strict = true): void
     {
         Assert::assertSame($expect, $result->contains($value, strict: $strict));
@@ -55,9 +56,9 @@ final class ContainsTest extends TestCase
     }
 
     /**
-     * @dataProvider containsErrMatrix
      * @param Result<mixed, null> $result
      */
+     #[DataProvider('containsErrMatrix')]
     public function testContainsErr(Result $result, mixed $value, bool $expect, bool $strict = true): void
     {
         Assert::assertSame($expect, $result->containsErr($value, strict: $strict));

--- a/tests/Unit/Result/ConvertToOptionTest.php
+++ b/tests/Unit/Result/ConvertToOptionTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Option;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
@@ -13,10 +14,10 @@ final class ConvertToOptionTest extends TestCase
     use Provider\Transpose;
 
     /**
-     * @dataProvider okMatrix
      * @param Result<mixed, mixed> $result
      * @param Option<mixed> $expected
      */
+     #[DataProvider('okMatrix')]
     public function testOk(Result $result, Option $expected): void
     {
         Assert::assertEquals($expected, $result->ok());
@@ -39,10 +40,10 @@ final class ConvertToOptionTest extends TestCase
     }
 
     /**
-     * @dataProvider errMatrix
      * @param Result<mixed, mixed> $result
      * @param Option<mixed> $expected
      */
+     #[DataProvider('errMatrix')]
     public function testErr(Result $result, Option $expected): void
     {
         Assert::assertEquals($expected, $result->err());
@@ -67,10 +68,10 @@ final class ConvertToOptionTest extends TestCase
     /**
      * @template T
      * @template E
-     * @dataProvider transposeMatrix
      * @param Result<Option<T>, E> $expected
      * @param Option<Result<T,E>> $option
      */
+     #[DataProvider('transposeMatrix')]
     public function testTranspose(Option $option, Result $expected): void
     {
         Assert::assertEquals($option, $option2 = Result\transpose($expected));

--- a/tests/Unit/Result/ExtendsTest.php
+++ b/tests/Unit/Result/ExtendsTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
 use TH\Maybe\Tests\Helpers;
@@ -29,10 +30,10 @@ final class ExtendsTest extends TestCase
     /**
      * Allowing overriding constructors would make the "Must be used" feature unsafe
      *
-     * @dataProvider resultClasses
      * @param class-string<Result<mixed,mixed>> $resultClass
      * @throws \ReflectionException
      */
+     #[DataProvider('resultClasses')]
     public function testConstructorsCannotBeOverriden(string $resultClass): void
     {
         $rc = new \ReflectionClass($resultClass);
@@ -42,9 +43,9 @@ final class ExtendsTest extends TestCase
     }
 
     /**
-     * @dataProvider resultMethods
      * @throws \ReflectionException
      */
+     #[DataProvider('resultMethods')]
     public function testOkResultMethodsCannotBeOverriden(string $method): void
     {
         $rc = new \ReflectionClass(Result\Ok::class);
@@ -55,9 +56,9 @@ final class ExtendsTest extends TestCase
     }
 
     /**
-     * @dataProvider resultMethods
      * @throws \ReflectionException
      */
+     #[DataProvider('resultMethods')]
     public function testErrResultMethodsCannotBeOverriden(string $method): void
     {
         $rc = new \ReflectionClass(Result\Err::class);

--- a/tests/Unit/Result/FlattenTest.php
+++ b/tests/Unit/Result/FlattenTest.php
@@ -3,16 +3,17 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
 
 final class FlattenTest extends TestCase
 {
     /**
-     * @dataProvider flattenMatrix
      * @param Result<mixed, null> $expected
      * @param Result<Result<mixed, null>, null> $result
      */
+     #[DataProvider('flattenMatrix')]
     public function testFlatten(Result $expected, Result $result): void
     {
         Assert::assertResultNotUsed($result);

--- a/tests/Unit/Result/InspectTest.php
+++ b/tests/Unit/Result/InspectTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
 use TH\Maybe\Tests\Provider;
@@ -12,8 +13,8 @@ final class InspectTest extends TestCase
     use Provider\Values;
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testInspectOk(mixed $value): void
     {
         $result = Result\ok($value);
@@ -51,8 +52,8 @@ final class InspectTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testInspectErrNone(mixed $value): void
     {
         $result = Result\err($value);

--- a/tests/Unit/Result/IsTest.php
+++ b/tests/Unit/Result/IsTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
 use TH\Maybe\Tests\Provider;
@@ -12,8 +13,8 @@ final class IsTest extends TestCase
     use Provider\Values;
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testIsOk(mixed $value): void
     {
         $result = Result\ok($value);
@@ -28,8 +29,8 @@ final class IsTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testIsErr(mixed $value): void
     {
         $result = Result\ok($value);
@@ -44,8 +45,8 @@ final class IsTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testIsOkAnd(mixed $value): void
     {
         $result = Result\ok($value);
@@ -62,8 +63,8 @@ final class IsTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testIsErrAnd(mixed $value): void
     {
         $result = Result\ok($value);

--- a/tests/Unit/Result/MapTest.php
+++ b/tests/Unit/Result/MapTest.php
@@ -3,13 +3,13 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
 
 final class MapTest extends TestCase
 {
     /**
-     * @dataProvider mapMatrix
      * @template T
      * @template U
      * @param Result<T, null> $result
@@ -17,6 +17,7 @@ final class MapTest extends TestCase
      * @param Result<U, null> $expected
      * @param array<T> $expectedCalls
      */
+     #[DataProvider('mapMatrix')]
     public function testMap(Result $result, mixed $mapResult, Result $expected, array $expectedCalls): void
     {
         $calls = [];
@@ -63,7 +64,6 @@ final class MapTest extends TestCase
     }
 
     /**
-     * @dataProvider mapErrMatrix
      * @template T
      * @template U
      * @param Result<T, null> $result
@@ -71,6 +71,7 @@ final class MapTest extends TestCase
      * @param Result<U, null> $expected
      * @param array<T> $expectedCalls
      */
+     #[DataProvider('mapErrMatrix')]
     public function testMapErr(Result $result, mixed $mapResult, Result $expected, array $expectedCalls): void
     {
         $calls = [];
@@ -117,7 +118,6 @@ final class MapTest extends TestCase
     }
 
     /**
-     * @dataProvider mapOrMatrix
      * @template T
      * @template U
      * @param Result<T, null> $result
@@ -126,6 +126,7 @@ final class MapTest extends TestCase
      * @param U $expected
      * @param array<T> $expectedCalls
      */
+     #[DataProvider('mapOrMatrix')]
     public function testMapOr(
         Result $result,
         mixed $mapResult,

--- a/tests/Unit/Result/MustBeUsedTest.php
+++ b/tests/Unit/Result/MustBeUsedTest.php
@@ -4,15 +4,16 @@ namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Result\UnusedResultException;
 
 final class MustBeUsedTest extends TestCase
 {
     /**
-     * @dataProvider resultsFactory
      * @param callable(): Result<mixed, mixed> $factory
      */
+     #[DataProvider('resultsFactory')]
     public function testNotUsingAResultThrowAnExceptionWhenFreed(callable $factory): void
     {
         $this->expectException(UnusedResultException::class);
@@ -25,9 +26,9 @@ final class MustBeUsedTest extends TestCase
     }
 
     /**
-     * @dataProvider resultsFactory
      * @param callable(): Result<mixed, mixed> $factory
      */
+     #[DataProvider('resultsFactory')]
     public function testUsingAResultAvoidTheExceptionWhenFreed(callable $factory): void
     {
         (static function (callable $factory): void {
@@ -37,9 +38,9 @@ final class MustBeUsedTest extends TestCase
     }
 
     /**
-     * @dataProvider resultsFactory
      * @param callable(): Result<mixed, mixed> $factory
      */
+     #[DataProvider('resultsFactory')]
     public function testAClonedResultMustBeUsed(callable $factory): void
     {
         $this->expectException(UnusedResultException::class);
@@ -56,9 +57,9 @@ final class MustBeUsedTest extends TestCase
     }
 
     /**
-     * @dataProvider resultsFactory
      * @param callable(): Result<mixed, mixed> $factory
      */
+     #[DataProvider('resultsFactory')]
     public function testAnUnserializedResultDontHaveToBeUsed(callable $factory): void
     {
         (static function (callable $factory): void {

--- a/tests/Unit/Result/TrapTest.php
+++ b/tests/Unit/Result/TrapTest.php
@@ -3,6 +3,7 @@
 namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Assert;
 use TH\Maybe\Tests\Provider;
@@ -12,8 +13,8 @@ final class TrapTest extends TestCase
     use Provider\Values;
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testTrapOk(mixed $value): void
     {
         $callback = static fn () => $value;

--- a/tests/Unit/Result/UnwrapTest.php
+++ b/tests/Unit/Result/UnwrapTest.php
@@ -4,6 +4,7 @@ namespace TH\Maybe\Tests\Unit\Result;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TH\Maybe\Result;
 use TH\Maybe\Tests\Provider;
 
@@ -19,8 +20,8 @@ final class UnwrapTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testExpectOk(mixed $value): void
     {
         Assert::assertSame($value, Result\ok($value)->expect("This should succeed"));
@@ -43,40 +44,40 @@ final class UnwrapTest extends TestCase
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOk(mixed $value): void
     {
         Assert::assertSame($value, Result\ok($value)->unwrap());
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOrErr(mixed $value): void
     {
         Assert::assertSame($value, Result\err(null)->unwrapOr($value));
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOrOk(mixed $value): void
     {
         Assert::assertSame($value, Result\ok($value)->unwrapOr(false));
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOrElseErr(mixed $value): void
     {
         Assert::assertSame($value, Result\err(null)->unwrapOrElse(static fn () => $value));
     }
 
     /**
-     * @dataProvider values
      */
+     #[DataProvider('values')]
     public function testUnwrapOrElseOk(mixed $value): void
     {
         Assert::assertSame($value, Result\ok($value)->unwrapOrElse(static fn () => false));


### PR DESCRIPTION
## Summary
- migrate `@dataProvider` annotations to `#[DataProvider]` attributes
- import `PHPUnit\Framework\Attributes\DataProvider` in all affected tests

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686bc08bcea083279c06593ac8f8e190